### PR TITLE
fix: add write options and support integer field in query

### DIFF
--- a/lib/web.ts
+++ b/lib/web.ts
@@ -102,7 +102,12 @@ export function toInfluxFormat(inputData: RequestPayload) {
                     serializedTags.push(`${key}=${inputPayload[key]}`);
                 } else {
                     //array of fields. Eg.: ["field1=value1", "field2=value2",....]
-                    const field = typeof inputPayload[key] === "string" ? `"${inputPayload[key]}"` : inputPayload[key];
+                    let field = inputPayload[key];
+                    if (typeof inputPayload[key] === "string") {
+                        if (!(inputPayload[key] as string).match(/\d+i/)) {
+                            field = `"${inputPayload[key]}"`;
+                        }
+                    }
                     serializedFields.push(`${key}=${field}`);
                 }
                 //delete the entry from input


### PR DESCRIPTION
- add query params and precision options to write api
- support integer field (ex. `10i`) in query