### PR TITLE
Feature/optional tag

### DIFF
--- a/lib/web.ts
+++ b/lib/web.ts
@@ -97,7 +97,7 @@ export function toInfluxFormat(inputData: RequestPayload) {
         //iterate over the keys
         for (const key in inputPayload) {
             if (Object.prototype.hasOwnProperty.call(inputPayload, key)) {
-                if(inputData.tags.includes(key)) {
+                if(inputData.tags){
                     //array of tags. Eg.: ["tag1=value1", "tag2=value2",....]
                     serializedTags.push(`${key}=${inputPayload[key]}`);
                 } else {
@@ -118,9 +118,11 @@ export function toInfluxFormat(inputData: RequestPayload) {
         result = result ? result + "\n" : result;
 
         //if tags present then comma after measurement field.
-        result += inputData.tags.length 
+        if(inputData.tags){
+            result += inputData.tags.length 
             ? `${inputData.measurement},${serializedTags.join(",")} ${serializedFields.join(",")}` 
             : `${inputData.measurement} ${serializedFields.join(",")}`;
+        }
         
         result += inputData.timestamp ? ` ${inputData.timestamp}` : ""; //update timestamp if explicitely provided
     }


### PR DESCRIPTION
If data is entered without a tag, an error occurs while referring to non-existent data.






 "stacktrace": [
            "TypeError: Cannot read property 'includes' of undefined",
            "    at toInfluxFormat (D:\\developer\\creo\\eight-waiter\\node_modules\\influxdb-light\\dist\\lib\\web.js:121:36)",
            "    at InfluxDB.writeV2 (D:\\developer\\creo\\eight-waiter\\node_modules\\influxdb-light\\dist\\lib\\index.js:39:66)",
            "    at RLogHttp (file:///D:/developer/creo/eight-waiter/Controller/LogController.js:32:14)",
            "    at Module.countTable (file:///D:/developer/creo/eight-waiter/Controller/Analyst/AnalyzeController.js:111:5)",
            "    at Object.countTable (file:///D:/developer/creo/eight-waiter/Controller/resolvers.js:72:70)",
            "    at field.resolve (D:\\developer\\creo\\eight-